### PR TITLE
Update Zig to 0.10.0 and use latest VC Redist

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,22 +1,16 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $packageName = 'zig'
-$packageVersion = '0.9.1'
+$packageVersion = '0.10.0'
 $packageZipFileName = "zig-windows-x86_64-$packageVersion"
 $packageDownloadUrl = "https://ziglang.org/download/$packageVersion/$packageZipFileName.zip"
-$packageChecksum = '443da53387d6ae8ba6bac4b3b90e9fef4ecbe545e1c5fa3a89485c36f5c0e3a2'
-$packageZipFileName32Bit = "zig-windows-i386-$packageVersion"
-$packageDownloadUrl32Bit = "https://ziglang.org/download/$packageVersion/$packageZipFileName32Bit.zip"
-$packageChecksum32Bit = '443da53387d6ae8ba6bac4b3b90e9fef4ecbe545e1c5fa3a89485c36f5c0e3a2'
+$packageChecksum = 'a66e2ff555c6e48781de1bcb0662ef28ee4b88af3af2a577f7b1950e430897ee'
 $packageChecksumType = 'sha256'
 
 $zigRoot = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
 
 Install-ChocolateyZipPackage -PackageName "$packageName" `
-    -Url "$packageDownloadUrl32Bit" `
     -Url64bit "$packageDownloadUrl" `
-    -Checksum "$packageChecksum32Bit" `
-    -ChecksumType "$packageChecksumType" `
     -Checksum64 "$packageChecksum" `
     -ChecksumType64 "$packageChecksumType" `
     -UnzipLocation "$zigRoot"

--- a/zig.nuspec
+++ b/zig.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zig</id>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
     <packageSourceUrl>https://github.com/euantorano/zig-chocolatey-package</packageSourceUrl>
     <owners>Euan Torano</owners>
 
@@ -12,10 +12,10 @@
     <projectUrl>https://ziglang.org</projectUrl>
     <iconUrl>http://cdn.rawgit.com/euantorano/zig-chocolatey-package/master/icons/zig-logo.png</iconUrl>
     <copyright>Copyright (c) 2015-2022, Zig contributors</copyright>
-    <licenseUrl>https://github.com/ziglang/zig/blob/0.9.1/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/ziglang/zig/blob/0.10.0/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/ziglang/zig</projectSourceUrl>
-    <docsUrl>https://ziglang.org/documentation/0.9.1/</docsUrl>
+    <docsUrl>https://ziglang.org/documentation/0.10.0/</docsUrl>
     <mailingListUrl>https://lists.sr.ht/~andrewrk/ziglang</mailingListUrl>
     <bugTrackerUrl>https://github.com/ziglang/zig/issues</bugTrackerUrl>
     <tags>zig development</tags>
@@ -26,7 +26,7 @@
 - **Optimal** - write programs the best way they can behave and perform.
 - **Clear** - precisely communicate your intent to the compiler and other programmers. The language imposes a low overhead to reading code.
     </description>
-    <releaseNotes>https://ziglang.org/download/0.9.1/release-notes.html</releaseNotes>
+    <releaseNotes>https://ziglang.org/download/0.10.0/release-notes.html</releaseNotes>
 
     <dependencies>
       <dependency id="vcredist140" version="14.30.30708" />

--- a/zig.nuspec
+++ b/zig.nuspec
@@ -29,7 +29,7 @@
     <releaseNotes>https://ziglang.org/download/0.10.0/release-notes.html</releaseNotes>
 
     <dependencies>
-      <dependency id="vcredist140" version="14.30.30708" />
+      <dependency id="vcredist140" version="14.32.31326" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
From the 0.10.0 release notes:
> The 32-bit Windows tarball is missing for this release due to [#12886](https://github.com/ziglang/zig/issues/12886). It will be available again in the [0.10.1](https://github.com/ziglang/zig/milestone/18) bugfix release.